### PR TITLE
Update BASS_SampleGetChannel for 2.4.16 changes

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -289,6 +289,10 @@ pub const BASS_3DALG_OFF: DWORD = 1;
 pub const BASS_3DALG_FULL: DWORD = 2;
 pub const BASS_3DALG_LIGHT: DWORD = 3;
 
+// BASS_SampleGetChannel flags
+pub const BASS_SAMCHAN_NEW: DWORD = 1;
+pub const BASS_SAMCHAN_STREAM: DWORD = 2;
+
 pub const BASS_STREAMPROC_END: DWORD = 0x80000000; // end of user stream flag
 
 // BASS_StreamCreateFileUser file systems

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -114,7 +114,7 @@ generate_bindings! {
     binding BASS_SAMPLE_GET_DATA fn BASS_SampleGetData(handle: HSAMPLE, buffer: *mut c_void) -> BOOL;
     binding BASS_SAMPLE_GET_INFO fn BASS_SampleGetInfo(handle: HSAMPLE, info: *mut BassSample) -> BOOL;
     binding BASS_SAMPLE_SET_INFO fn BASS_SampleSetInfo(handle: HSAMPLE, info: *const BassSample) -> BOOL;
-    binding BASS_SAMPLE_GET_CHANNEL fn BASS_SampleGetChannel(handle: HSAMPLE, only_new: BOOL) -> HCHANNEL;
+    binding BASS_SAMPLE_GET_CHANNEL fn BASS_SampleGetChannel(handle: HSAMPLE, flags: DWORD) -> HCHANNEL;
     binding BASS_SAMPLE_GET_CHANNELS fn BASS_SampleGetChannels(handle: HSAMPLE, channels: *mut HCHANNEL) -> DWORD;
     binding BASS_SAMPLE_STOP fn BASS_SampleStop(handle: HSAMPLE) -> BOOL;
     binding BASS_STREAM_CREATE fn BASS_StreamCreate(


### PR DESCRIPTION
BASS_SampleGetChannel takes in flags instead of just a bool as of 2.4.16, as shown in http://www.un4seen.com/doc/#bass/BASS_SampleGetChannel.html